### PR TITLE
chore: bump typedoc-plugin-to-skills to ^1.3.0

### DIFF
--- a/.changeset/1777046805.md
+++ b/.changeset/1777046805.md
@@ -1,0 +1,11 @@
+---
+  "@dependabit/action": patch
+  "@dependabit/detector": patch
+  "@dependabit/github-client": patch
+  "@dependabit/manifest": patch
+  "@dependabit/monitor": patch
+  "@dependabit/test-utils": patch
+  "@dependabit/utils": patch
+---
+
+- chore: bump typedoc-plugin-to-skills to ^1.3.0

--- a/.changeset/1777046805.md
+++ b/.changeset/1777046805.md
@@ -1,11 +1,11 @@
 ---
-  "@dependabit/action": patch
-  "@dependabit/detector": patch
-  "@dependabit/github-client": patch
-  "@dependabit/manifest": patch
-  "@dependabit/monitor": patch
-  "@dependabit/test-utils": patch
-  "@dependabit/utils": patch
+"@dependabit/action": patch
+"@dependabit/detector": patch
+"@dependabit/github-client": patch
+"@dependabit/manifest": patch
+"@dependabit/monitor": patch
+"@dependabit/test-utils": patch
+"@dependabit/utils": patch
 ---
 
 - chore: bump typedoc-plugin-to-skills to ^1.3.0

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -83,7 +83,7 @@ jobs:
             PRIVATE=$(jq -r '.private // false' "$pkg_json" 2>/dev/null || echo 'false')
             NAME=$(jq -r '.name // ""' "$pkg_json" 2>/dev/null || echo '')
             if [ "$PRIVATE" != "true" ] && [ -n "$NAME" ] && [ "$NAME" != "null" ]; then
-              FRONTMATTER="${FRONTMATTER}  \"${NAME}\": ${TYPE}\n"
+              FRONTMATTER="${FRONTMATTER}\"${NAME}\": ${TYPE}\n"
             fi
           done
 
@@ -92,7 +92,7 @@ jobs:
             PRIVATE=$(jq -r '.private // false' "package.json" 2>/dev/null || echo 'false')
             NAME=$(jq -r '.name // ""' "package.json" 2>/dev/null || echo '')
             if [ "$PRIVATE" != "true" ] && [ -n "$NAME" ] && [ "$NAME" != "null" ]; then
-              FRONTMATTER="  \"${NAME}\": ${TYPE}\n"
+              FRONTMATTER="\"${NAME}\": ${TYPE}\n"
             fi
           fi
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "typedoc": "0.28.19",
     "typedoc-plugin-markdown": "^4.11.0",
-    "typedoc-plugin-to-skills": "^1.0.2",
+    "typedoc-plugin-to-skills": "^1.3.0",
     "typedoc-vitepress-theme": "^1.1.2",
     "vitepress": "2.0.0-alpha.17",
     "vue": "^3.5.32"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "simple-git-hooks": "^2.13.1",
     "typedoc": "^0.28.19",
     "typedoc-plugin-markdown": "^4.11.0",
-    "typedoc-plugin-to-skills": "^0.6.6",
+    "typedoc-plugin-to-skills": "^1.3.0",
     "vitest": "^4.1.5"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^4.11.0
         version: 4.11.0(typedoc@0.28.19(typescript@6.0.3))
       typedoc-plugin-to-skills:
-        specifier: ^0.6.6
-        version: 0.6.6(typedoc@0.28.19(typescript@6.0.3))
+        specifier: ^1.3.0
+        version: 1.3.0(typedoc@0.28.19(typescript@6.0.3))
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -63,7 +63,7 @@ importers:
         specifier: ^4.11.0
         version: 4.11.0(typedoc@0.28.19(typescript@6.0.3))
       typedoc-plugin-to-skills:
-        specifier: ^1.0.2
+        specifier: ^1.3.0
         version: 1.3.0(typedoc@0.28.19(typescript@6.0.3))
       typedoc-vitepress-theme:
         specifier: ^1.1.2
@@ -1400,19 +1400,11 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@to-skills/core@0.10.3':
-    resolution: {integrity: sha512-xPQsfY30rrIZThu13d/AFzUnXNySPC1hG+6xbnvEe3Z1ZZZgHc4u8KP+IcrAa/YX1gKbkr4x9Bog2tZTDrYYxw==}
-
   '@to-skills/core@1.0.1':
     resolution: {integrity: sha512-+ThSJwQVJB0Hf/97VFBfqxQXlVO305pZorcMY5j6GzRtGFxs1w85Iwjdm+bQTeZnAiUjVh8o2zhmX3Miv544Yw==}
 
   '@to-skills/core@1.3.0':
     resolution: {integrity: sha512-rK0NPuUJAKhja6PZ7o1WRVCeqgJIg9jooiWhWPy6KYVTnMRgDkOvvFFSB5WmprdWqMgewp5I2weSbB9d8A3khg==}
-
-  '@to-skills/typedoc@0.11.4':
-    resolution: {integrity: sha512-FFGhyx/tEtzbQQxNFGGdbLO8tNXtwwL1O9izTBaElwrzDPJHa12SsLIakD5NlyeKn+YOOKLGnKFKjxy+5eNVPw==}
-    peerDependencies:
-      typedoc: '>=0.28.0'
 
   '@to-skills/typedoc@1.0.8':
     resolution: {integrity: sha512-0c3/7Hzse5/1InGXT0DGObsJjs9F+Zj8lWPSI6xI5AAMGlKAkKxbOSK/XM4tsdIIFSt7lTa8UriAnpcxKZZ0GA==}
@@ -2409,11 +2401,6 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       typedoc: 0.28.x
-
-  typedoc-plugin-to-skills@0.6.6:
-    resolution: {integrity: sha512-iusBTiIW4HuSq3qhDSVZGc9feNq1N7cI4L03n8g63JRG4pJQdg9ZRWe/ZE4OnSLt/m2+Mn2+jHayAr+ArxHzwQ==}
-    peerDependencies:
-      typedoc: '>=0.28.0'
 
   typedoc-plugin-to-skills@1.3.0:
     resolution: {integrity: sha512-SULAFaFt1FVfYoCuzZa11CEmenairdDExTwoEDRWOC6DE7a8uTnd0h5PBgwegEkVq1A8g4D256Uxk9DrgcCt6w==}
@@ -3421,16 +3408,9 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@to-skills/core@0.10.3': {}
-
   '@to-skills/core@1.0.1': {}
 
   '@to-skills/core@1.3.0': {}
-
-  '@to-skills/typedoc@0.11.4(typedoc@0.28.19(typescript@6.0.3))':
-    dependencies:
-      '@to-skills/core': 0.10.3
-      typedoc: 0.28.19(typescript@6.0.3)
 
   '@to-skills/typedoc@1.0.8(typedoc@0.28.19(typescript@6.0.3))':
     dependencies:
@@ -4466,11 +4446,6 @@ snapshots:
 
   typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3)):
     dependencies:
-      typedoc: 0.28.19(typescript@6.0.3)
-
-  typedoc-plugin-to-skills@0.6.6(typedoc@0.28.19(typescript@6.0.3)):
-    dependencies:
-      '@to-skills/typedoc': 0.11.4(typedoc@0.28.19(typescript@6.0.3))
       typedoc: 0.28.19(typescript@6.0.3)
 
   typedoc-plugin-to-skills@1.3.0(typedoc@0.28.19(typescript@6.0.3)):


### PR DESCRIPTION
## Summary

- Bumps `typedoc-plugin-to-skills` from `^0.6.6` → `^1.3.0` in `package.json`
- Bumps `typedoc-plugin-to-skills` from `^1.0.2` → `^1.3.0` in `apps/docs/package.json`

`typedoc-plugin-to-skills` is a first-party plugin from the `to-skills` monorepo. Version 1.3.0 is now the current stable release across the portfolio.

## Test plan

- [ ] `pnpm install` resolves without errors
- [ ] `pnpm run docs:build` generates docs successfully

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUrmQ6e4PoYCvmZdsq5KMG)_